### PR TITLE
Add first-version support for timing asm. Only supports int64_t arguments

### DIFF
--- a/timer.c
+++ b/timer.c
@@ -5,7 +5,9 @@
 #include <stdlib.h>
 INCLUDES_HERE
 
-#define PERF_ITRS 20000000
+FUNCTIONS_HERE
+
+#define PERF_ITRS 200000
 
 static inline uint64_t rdtscp(){
   uint64_t v;


### PR DESCRIPTION
Example use:
timer.add_asm_test("div", div_inputs,  "div %%rcx", ('=a', '=d'), ("d", "a", "c"), ())

A little bit hacky.
